### PR TITLE
Fix a bug with `audit --kubernetes-directory` arg

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -38,12 +38,18 @@ import (
 
 var kubernetesDirectory string
 
-func init() {
+func getDefaultKubernetesDirectory() string {
 	val, ok := os.LookupEnv("GOPATH")
-	if ok {
-		kubernetesDirectory = path.Join(val, "src/k8s.io/kubernetes")
+	if !ok {
+		fmt.Print("WARN: GOPATH not set")
+		return ""
 	}
-	auditCmd.Flags().StringVar(&outputFile, "kubernetes-directory", kubernetesDirectory, "path to kubernetes directory")
+
+	return path.Join(val, "src/k8s.io/kubernetes")
+}
+
+func init() {
+	auditCmd.Flags().StringVar(&kubernetesDirectory, "kubernetes-directory", getDefaultKubernetesDirectory(), "path to kubernetes directory")
 	rootCmd.AddCommand(auditCmd)
 }
 


### PR DESCRIPTION
The flag was initializing the outputFile variable instead of the
kubernetesDirectory variable.

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>
