### PR TITLE
Add version subcommand to show version information

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -27,7 +27,7 @@ jobs:
           path: ${{ github.workspace }}/src/github.com/dims/maintainers/
 
       - name: Build
-        run: go install .
+        run: make install
         working-directory: ${{ github.workspace }}/src/github.com/dims/maintainers/
 
       - name: Checkout kubernetes/community

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: install
+
+install:
+	./hack/install-maintainers.sh

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,21 +13,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/dims/maintainers/pkg/version"
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "maintainers",
-	Short: "tool for maintaining OWNERS files in kubernetes hello",
+func init() {
+	rootCmd.AddCommand(versionCmd)
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
+// versionCmd sets up a Cobra command for version info
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "show version information",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.Get())
+	},
 }

--- a/hack/install-maintainers.sh
+++ b/hack/install-maintainers.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+# check if git tree is clean
+git_tree_state=dirty
+if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${git_status}" ]]; then
+    git_tree_state=clean
+fi
+
+version_pkg=github.com/dims/maintainers/pkg/version
+bin_name=maintainers
+
+MAINTAINERS_INSTALL_PATH="${GOPATH}/bin"
+
+if [ -n "${GOBIN:-}" ]; then
+    MAINTAINERS_INSTALL_PATH="${GOBIN}"
+fi
+
+if [[ ":$PATH:" != *":$MAINTAINERS_INSTALL_PATH:"* ]]; then
+    # setup install path
+    export PATH="${PATH}:${MAINTAINERS_INSTALL_PATH}"
+fi
+
+# build maintainers
+go build -v -trimpath -ldflags "-s -w \
+-X $version_pkg.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+-X $version_pkg.gitCommit=$(git rev-parse HEAD 2>/dev/null || echo unknown) \
+-X $version_pkg.gitTreeState=$git_tree_state \
+-X $version_pkg.gitVersion=$(git describe --tags --abbrev=0 || echo unknown)" \
+-o "$MAINTAINERS_INSTALL_PATH/$bin_name" . \
+|| exit 1
+
+echo "$bin_name installed to $MAINTAINERS_INSTALL_PATH"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+)
+
+var (
+	gitVersion   string // semantic version, derived by build scripts
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string // state of git tree, either "clean" or "dirty"
+	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+type Info struct {
+	GitVersion   string
+	GitCommit    string
+	GitTreeState string
+	BuildDate    string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func Get() *Info {
+	return &Info{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns the string representation of the version info
+func (i *Info) String() string {
+	b := strings.Builder{}
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+
+	w.Flush()
+	return b.String()
+}


### PR DESCRIPTION
Inspired by https://pkg.go.dev/k8s.io/release@v0.12.0/pkg/version, added a `version` subcommand to help developers with version information when they use the tool or contribute to it.

Changes:
- pkg: add version
- cmd: add version subcommand to show version information
- hack: add Makefile and a install script to install maintainers
