### PR TITLE
Fix: Print tool errors only once

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -29,6 +28,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,6 +51,7 @@ func getDefaultKubernetesDirectory() string {
 
 func init() {
 	auditCmd.Flags().StringVar(&kubernetesDirectory, "kubernetes-directory", getDefaultKubernetesDirectory(), "path to kubernetes directory")
+	auditCmd.SilenceErrors = true
 	rootCmd.AddCommand(auditCmd)
 }
 

--- a/cmd/checkurl.go
+++ b/cmd/checkurl.go
@@ -32,6 +32,7 @@ var yamlFile string
 
 func init() {
 	checkURLsCmd.Flags().StringVar(&yamlFile, "yaml-file", "sigs.yaml", "validate urls in this yaml file")
+	checkURLsCmd.SilenceErrors = true
 	rootCmd.AddCommand(checkURLsCmd)
 }
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -18,11 +18,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -51,6 +52,7 @@ var outputFile string
 
 func init() {
 	exportCmd.Flags().StringVar(&outputFile, "output", "export.csv", "output file path")
+	exportCmd.SilenceErrors = true
 	rootCmd.AddCommand(exportCmd)
 }
 

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -18,10 +18,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"sort"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -50,6 +51,7 @@ var labelsFile string
 
 func init() {
 	labelsCmd.Flags().StringVar(&labelsFile, "output", "labels.csv", "output file path")
+	labelsCmd.SilenceErrors = true
 	rootCmd.AddCommand(labelsCmd)
 }
 

--- a/cmd/prettify.go
+++ b/cmd/prettify.go
@@ -88,6 +88,7 @@ var prettifyCmd = &cobra.Command{
 }
 
 func init() {
+	prettifyCmd.SilenceErrors = true
 	rootCmd.AddCommand(prettifyCmd)
 }
 

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -18,12 +18,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -46,6 +47,7 @@ func init() {
 	pruneCmd.Flags().StringVar(&periodDS, "period-devstats", "y", "one of \"y\" (year) \"q\" (quarter) \"m\" (month) ")
 	pruneCmd.Flags().StringSliceVar(&excludeFiles, "exclude-files", []string{}, "do not update these OWNERS files")
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	pruneCmd.SilenceErrors = true
 	rootCmd.AddCommand(pruneCmd)
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -139,5 +139,6 @@ func validateOwnersFilesInGroups(groupMap *map[string][]utils.Group) (map[string
 }
 
 func init() {
+	validateCmd.SilenceErrors = true
 	rootCmd.AddCommand(validateCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,6 +23,7 @@ import (
 )
 
 func init() {
+	versionCmd.SilenceErrors = true
 	rootCmd.AddCommand(versionCmd)
 }
 


### PR DESCRIPTION
Set `SilenceErrors` to `true` for all commands

Signed-off-by: Raghav Roy <raghavroy145@gmail.com>