### PR TITLE
Return slice and map to functions instead of pointers 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "maintainers",
-	Short: "tool for maintaining OWNERS files in kubernetes hello",
+	Short: "tool for maintaining OWNERS files in kubernetes",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -69,7 +69,7 @@ var validateCmd = &cobra.Command{
 		}
 
 		groupMap := context.PrefixToGroupMap()
-		fileMap, errors := validateOwnersFilesInGroups(&groupMap)
+		fileMap, errors := validateOwnersFilesInGroups(groupMap)
 		errors2 := warnFileMismatchesBetweenKubernetesRepoAndSigsYaml(fileMap)
 		errors = append(errors, errors2...)
 
@@ -94,7 +94,7 @@ func warnFileMismatchesBetweenKubernetesRepoAndSigsYaml(fileMap map[string]strin
 			continue
 		}
 		found := false
-		for _, file := range *ownerFiles {
+		for _, file := range ownerFiles {
 			if len(file) == 0 {
 				continue
 			}
@@ -107,7 +107,7 @@ func warnFileMismatchesBetweenKubernetesRepoAndSigsYaml(fileMap map[string]strin
 		}
 	}
 
-	for _, file := range *ownerFiles {
+	for _, file := range ownerFiles {
 		if len(file) > 0 {
 			if _, ok := fileMap[file]; !ok {
 				errors = append(errors, fmt.Errorf("file [%s] is not in sigs.yaml", file))
@@ -118,10 +118,10 @@ func warnFileMismatchesBetweenKubernetesRepoAndSigsYaml(fileMap map[string]strin
 	return errors
 }
 
-func validateOwnersFilesInGroups(groupMap *map[string][]utils.Group) (map[string]string, []error) {
+func validateOwnersFilesInGroups(groupMap map[string][]utils.Group) (map[string]string, []error) {
 	fileMap := map[string]string{}
 	var errors []error
-	for groupType, groups := range *groupMap {
+	for groupType, groups := range groupMap {
 		for _, group := range groups {
 			for _, sub := range group.Subprojects {
 				for _, filePath := range sub.Owners {

--- a/pkg/utils/github_utils.go
+++ b/pkg/utils/github_utils.go
@@ -76,7 +76,7 @@ func FetchPRCommentCount(user, repository string) (int, error) {
 	return strconv.Atoi(fmt.Sprintf("%v", result["total_count"]))
 }
 
-func GetKubernetesOwnersFiles() (*[]string, error) {
+func GetKubernetesOwnersFiles() ([]string, error) {
 	resp, err := http.Get("https://api.github.com/repos/kubernetes/kubernetes/git/trees/master?recursive=1")
 	if err != nil {
 		return nil, err
@@ -108,5 +108,5 @@ func GetKubernetesOwnersFiles() (*[]string, error) {
 			directories = append(directories, directory.Path)
 		}
 	}
-	return &directories, nil
+	return directories, nil
 }


### PR DESCRIPTION
This PR relates to issue: https://github.com/dims/maintainers/issues/12

**Changes Include**

- Removed pointers to slice and map when returned to some functions: `GetKubernetesOwnersFiles`, `validateOwnersFilesInGroups`