### PR TITLE
Change module path to include org as `kubernetes-sigs` and bump Go version

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18.1
 
       - name: Set env
         shell: bash

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -24,11 +24,11 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          path: ${{ github.workspace }}/src/github.com/dims/maintainers/
+          path: ${{ github.workspace }}/src/github.com/kubernetes-sigs/maintainers/
 
       - name: Build
         run: make install
-        working-directory: ${{ github.workspace }}/src/github.com/dims/maintainers/
+        working-directory: ${{ github.workspace }}/src/github.com/kubernetes-sigs/maintainers/
 
       - name: Checkout kubernetes/community
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ updating these files.
 
 You can also validate/check if all the urls in a file are correct using `check-urls`
 ```bash
-[dims@dims-m1 11:31] ~/go/src/k8s.io/community ⟩ ~/go/src/github.com/dims/maintainers/maintainers help check-urls
+[dims@dims-m1 11:31] ~/go/src/k8s.io/community ⟩ ~/go/src/github.com/kubernetes-sigs/maintainers/maintainers help check-urls
 ensure all the urls in yaml file are still valid
 
 Usage:
@@ -80,7 +80,7 @@ The new `audit` command is helpful to kubernetes chairs and leads as it vets the
 
 Notes:
 - ensure kubernetes/community and kubernetes/kubernetes is checked out under $GOPATH/src/k8s.io
-- install the tool using `go install github.com/dims/maintainers@v0.2.0` (where v0.2.0 is latest tag as of right now, please check for newer tags)
+- install the tool using `go install github.com/kubernetes-sigs/maintainers@v0.2.0` (where v0.2.0 is latest tag as of right now, please check for newer tags)
 - change directory to `$GOPATH/src/k8s.io/community` directory and run `maintainers audit sig-auth` (or your own sig) and review the output.
 
 ```bash

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -34,7 +34,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/dims/maintainers/pkg/utils"
+	"github.com/kubernetes-sigs/maintainers/pkg/utils"
 )
 
 var kubernetesDirectory string

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -27,7 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/dims/maintainers/pkg/utils"
+	"github.com/kubernetes-sigs/maintainers/pkg/utils"
 )
 
 // exportCmd represents the export command

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/dims/maintainers/pkg/utils"
+	"github.com/kubernetes-sigs/maintainers/pkg/utils"
 )
 
 // labelsCmd represents the export command

--- a/cmd/prettify.go
+++ b/cmd/prettify.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/dims/maintainers/pkg/utils"
+	"github.com/kubernetes-sigs/maintainers/pkg/utils"
 )
 
 var indent int

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -28,7 +28,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/dims/maintainers/pkg/utils"
+	"github.com/kubernetes-sigs/maintainers/pkg/utils"
 )
 
 var dryRun, skipGH, skipDS bool

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dims/maintainers/pkg/utils"
+	"github.com/kubernetes-sigs/maintainers/pkg/utils"
 )
 
 // validateCmd represents the validate command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/dims/maintainers/pkg/version"
+	"github.com/kubernetes-sigs/maintainers/pkg/version"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/maintainers
 
-go 1.17
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dims/maintainers
+module github.com/kubernetes-sigs/maintainers
 
 go 1.17
 

--- a/hack/install-maintainers.sh
+++ b/hack/install-maintainers.sh
@@ -6,7 +6,7 @@ if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${g
     git_tree_state=clean
 fi
 
-version_pkg=github.com/dims/maintainers/pkg/version
+version_pkg=github.com/kubernetes-sigs/maintainers/pkg/version
 bin_name=maintainers
 
 MAINTAINERS_INSTALL_PATH="${GOPATH}/bin"

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "github.com/dims/maintainers/cmd"
+import "github.com/kubernetes-sigs/maintainers/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This PR introduces 2 commits:

- The first commit changes the Go module path
- The second commit bumps the Go version to 1.18

xref https://github.com/kubernetes/test-infra/pull/26165#discussion_r864412073

/assign @nikhita 
/cc @RaghavRoy145 