### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -28,8 +29,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/kubernetes-sigs/maintainers
 go 1.18
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.3.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -314,7 +314,6 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/utils/devstats_utils.go
+++ b/pkg/utils/devstats_utils.go
@@ -23,8 +23,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func GetContributionsForAYear(repository string, period string) ([]Contribution, error) {
@@ -53,7 +51,7 @@ func GetContributionsForAYear(repository string, period string) ([]Contribution,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Wrap(err, fmt.Sprintf("bad error code from devstats: %d", resp.StatusCode))
+		return nil, fmt.Errorf("bad error code from devstats: %d: %w", resp.StatusCode, err)
 	}
 
 	var parsed map[string]map[string]map[string][]Frames
@@ -63,7 +61,7 @@ func GetContributionsForAYear(repository string, period string) ([]Contribution,
 	}
 	err = json.Unmarshal(body, &parsed)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse json from devstats")
+		return nil, fmt.Errorf("unable to parse json from devstats: %w", err)
 	}
 
 	foo := parsed["results"]["A"]["frames"][0].Data.Items[0]


### PR DESCRIPTION
We now use the native error wrapping support since github.com/pkg/errors is read-only.