### PR TITLE
Check that GOPATH is set and exit with a helpful error message if not

### DIFF
--- a/hack/install-maintainers.sh
+++ b/hack/install-maintainers.sh
@@ -1,5 +1,10 @@
 #! /usr/bin/env bash
 
+if [ -z $GOPATH ]; then
+    echo "GOPATH must be set to run this script"
+    exit 1
+fi
+
 # check if git tree is clean
 git_tree_state=dirty
 if git_status=$(git status --porcelain --untracked=no 2>/dev/null) && [[ -z "${git_status}" ]]; then


### PR DESCRIPTION
Added a quick check to make sure that GOPATH is set and if not, the script exits with an error message before continuing to remind the user to set their GOPATH before running make again.

Fixes Issue #18 