### PR TITLE
Skip _output folder when scanning for OWNERS files

### DIFF
--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -94,7 +94,7 @@ func GetOwnerFiles(root string) ([]string, error) {
 		if info.IsDir() {
 			return nil
 		}
-		if filepath.Base(path) == "OWNERS" && !strings.Contains(path, "vendor") {
+		if filepath.Base(path) == "OWNERS" && !strings.Contains(path, "vendor") && !strings.Contains(path, "_output") {
 			matches = append(matches, path)
 		}
 		return nil


### PR DESCRIPTION
part of #12 

## What

- skip the `_output` folder when scanning for OWNERS files, similar to how it currently skips `vendor`.

## Why

When running `maintainers prune` on k/k clone that has an `_output` folder (created by `make update` or similar build commands), the tool fails due to OWNERS files in vendored dependencies within `_output`.

## How to Reproduce

```bash
cd /path/to/kubernetes/kubernetes
mkdir -p _output/local/go/pkg/mod/k8s.io/some-module/
maintainers prune --skip-github --skip-devstats
```

**Result:**
```
Error: error processing /path/to/kubernetes/_output/local/go/pkg/mod/k8s.io/some-module/OWNERS: error unmarshaling JSON: while decoding JSON: json: unknown field "emritus_approvers"
```